### PR TITLE
Postgres hardened with client certificate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@ client-app/project/project/
 client-app/project/target/
 client-app/target/
 env.sh-backup
+jSSLKeyLog.jar
+client.p12
+import.pem
+server.p12
+sockets/client/SSLSocketClient.class
+sockets/client/SSLSocketClientWithClientAuth.class
+sockets/client/jssl-key.log
+sockets/server/ClassFileServer.class
+sockets/server/ClassServer.class
+sockets/server/jssl-key.log

--- a/Documentation/Auth0Setup.md
+++ b/Documentation/Auth0Setup.md
@@ -260,7 +260,7 @@ automated testing, for example CI/CD.
 
 [Build DAML Application](./BuildSteps.md)
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 

--- a/Documentation/BuildSteps.md
+++ b/Documentation/BuildSteps.md
@@ -45,5 +45,5 @@ The last step is not absolutely necessary but useful to check that the app compi
 
 [Starting Services](./StartingServices.md)
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/Documentation/CoreConcepts.md
+++ b/Documentation/CoreConcepts.md
@@ -229,5 +229,5 @@ The Scala source code for the Authorization Claims processing is [Here](https://
 
 [Getting Started](./GettingStarted.md)
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/Documentation/GettingStarted.md
+++ b/Documentation/GettingStarted.md
@@ -25,7 +25,7 @@ Before you can run the application, you need to install:
 - the [yarn](https://yarnpkg.com/en/docs/install) package manager for JavaScript.
 - grpcurl - to test secure GRPC calls 
 - jq - for JSON parsing 
-- openssl 1.1.0 - for PKI, TLS 1.3 and any other aspects
+- openssl 1.1.1j - for PKI, TLS 1.3 and any other aspects
 - Docker - to run postgres and nginx proxy
 - Python - jwcrypto library
 
@@ -145,5 +145,5 @@ Docker-compose setup uses internal network aliases to allow connections between 
 
 [PKI Setup](./PKISetup.md)
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/Documentation/ImplementationNotes.md
+++ b/Documentation/ImplementationNotes.md
@@ -95,5 +95,5 @@ https://prefetch.net/blog/2020/04/22/using-grpcurl-to-interact-with-grpc-applica
 https://bionic.fullstory.com/tale-of-grpcurl/
 
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/Documentation/NextSteps.md
+++ b/Documentation/NextSteps.md
@@ -34,7 +34,7 @@ We love to receive feedback on our products and these reference applications.
 
 Some notes on the implementation are available: [Implementation Notes](./ImplementationNotes.md)
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 

--- a/Documentation/PKISetup.md
+++ b/Documentation/PKISetup.md
@@ -168,5 +168,5 @@ though many of these features are detailed in the provided scripts (```test-ocsp
 
 [Auth0 Setup](./Auth0Setup.md)
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/Documentation/README.md
+++ b/Documentation/README.md
@@ -50,8 +50,12 @@ The sample is setup and run through the following steps:
 - [Next Steps & Resources](./NextSteps.md)
 - [Implementation Notes](./ImplementationNotes.md)
 
+## TechNotes / Interesting topics
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+- [PKI and Certificate Revocation (CRLs, OCSP, OCSP Stapling)](./technote-ocsp-cert-revocation.md)
+- [Postgres Database Hardening](./technote-postgresql.md)
+
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
 

--- a/Documentation/StartingServices.md
+++ b/Documentation/StartingServices.md
@@ -114,5 +114,5 @@ You can now test out your running ledger
 [Testing](./Testing.md)
 
 
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0

--- a/Documentation/Testing.md
+++ b/Documentation/Testing.md
@@ -111,7 +111,7 @@ decode and validate signatures. This is NOT RECOMMENDED for production tokens.
 # Next Step
  [Final Thoughts and Next Steps](./NextSteps.md)
  
-Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
 SPDX-License-Identifier: Apache-2.0
 
  

--- a/Documentation/technote-ocsp-cert-revocation.md
+++ b/Documentation/technote-ocsp-cert-revocation.md
@@ -1,0 +1,355 @@
+[![DAML logo](https://daml.com/wp-content/uploads/2020/03/logo.png)](https://www.daml.com)
+
+[![Download](https://img.shields.io/github/release/digital-asset/daml.svg?label=Download)](https://docs.daml.com/getting-started/installation.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/digital-asset/daml/blob/master/LICENSE)
+
+# TechNote: Certificate Revocation
+
+Digital certificates in the form of server-side TLS certificates and client-side mutual authentication certificates are used 
+to authenticate and protect data in transit. Mutual authentication allows both sides to validate who they are 
+connecting to and make decisions around whether this is acceptable. 
+
+However digital certificates can be lost, stolen, expired, revoked, and each side may want to perform further validation. Over the 
+years, many mechanisms have been developed to allow applications to validate the certificate and these have different tradeoffs.
+
+This TechNote documents the certificate revocation mechanisms, some options to enable debugging of the flows
+and some instructions on how to the use to provided test scripts and programs to test out revocation 
+options.
+
+## Types of Certificate Revocation Checks
+
+Certificate Revocation mechanisms include:
+
+- **Certificate Revocation Lists (CRL)**
+  - A signed list of Certificates that have been revoked by the CA
+- **OCSP**
+  - Protocol to allow clients of the Certificate Authority to request status of specific certs
+- **OCSP Stapling**
+  - Enhancement to OCSP to allow the server to "staple" the OCSP response removing need for individual clients to check
+- **OCSP Must-Staple**
+  - New extension for certificates for indicates to browsers they should expect an OCSP Staple response. This has limited support.
+- **Chrome CRLSets / Firefox OneCRL**
+  - Browser revocation standard where CRLS for primary public CAs are distributed to end-user browsers
+
+Below are some short descriptons of each mechanism and the drawebacks for each one. See the **References** for
+other articles that discuss these topics.
+
+**Certificate Revocation Lists (CRLs)** were the first method for checking certificates. This is a file containing a signed list of 
+certificates that have been revoked. Clients would download this list and validate certificates against this list. The main 
+challenge with their use is the size of the file can become very large, very quickly especially for busy CAs and systems would need
+to download this file frequently if they require quick revocation periods. In 
+general CRLS are not used in most systems today.
+
+**OCSP** was the next proposal on how to handle revocation. Instead of download the complete set, systems could
+make calls the the OCSP Responder of the CA for specific certificates and obtain a status of the 
+certificate. This resolves the size and frequency issues but introduces some new concerns. In particular,
+concerns include: availability concerns of the OCSP responder (Apple suffered an outage in 2020 when
+their OCSP server went offline temporarily); performance delays (each use of certificate required a call from the client and/or 
+server and waiting on the response during connection setup) and privacy concerns (the CA sees 
+all clients who are attempting to access any service they provide certificates for).
+
+**OCSP Stapling** attempts to solve the performance and privacy issues of OCSP. The server
+makes the OCSP call of behalf of all clients connecting to the service and "staples" the response
+in the Server response of the TLS negotiation. In this way, enabled clients receive
+a copy of the response with the certificate and can validate without needing to make OCSP calls themselves.
+This is still prone to availability concerns although the server can cache the OCSP response for a while. 
+
+The next two mechanisms wre mainly introduced for browsers and are not directly supported by
+the Java JDK.
+
+**OCSP Must-Staple**. OCSP has one failing in that many clients will Soft-Fail, i.e. allow connections
+to proceed if they do not receive an OCSP response in time. This leads toa false sense of security as
+clients will not fail closed. OCSP Must-Staple is a new Certificate extension that the 
+CA can set on each certificate requiring clients to receive and validate an 
+OCSP response for the certificate. Unfortunately client support for this extension is
+not complete.
+
+**Chrome CRLSet / Firefox OneCRL**. These are browser specific solutions to the 
+revocation issue. The browser vendors collate a list of CRLs for major Certificate Authority certificates (the CA 
+not the end leaf certificates) and distribute as part of their browser package. This resolves the download issue 
+but does not support other CAs or end-leaf certificates. It is focused on revoking CAs that
+are found to be compromised.
+
+**Other mechanisms**
+
+Another mechanism tat can be used is to issue certificates with short lifetimes. Connections are 
+restricted to short periods without incurring the revocation cost / complexity.
+
+# Java, TLS and Certificate Revocation, Debug Options
+
+Before we look at demonstrations of OCSP and OCSP Stapling with Java and Daml, here are some 
+techniques to debug the TLS connections and see what is happening on the wire.
+
+## To enable certificate revocation
+
+See Oracle documentation (link in **References**) around these options
+
+```
+# Add ocsp.enable=true into security properties. The following overrides
+-Djava.security.properties=$ROOTDIR/java.security
+
+# The following enables OCSP
+-Dcom.sun.net.ssl.checkRevocation=true 
+
+# Enable CRL checking
+-Dcom.sun.security.enableCRLDP=true
+
+# The following additionally enable OCSP Stapling
+-Djdk.tls.client.enableStatusRequestExtension=true 
+-Djdk.tls.server.enableStatusRequestExtension=true 
+```
+
+Implementation Notes:
+- Java JDK expects certificates to be in truststore format so TLS Client/Server example imports
+into Truststores and Keystores. See ```run-tls-server.sh```
+
+## Java TLS Debug options
+
+Debugging TLS issues can be challenging. The following enables debug logging to the JDK
+TLS stack, particularly ```certpath``` (Certificate validation), ```ocsp``` (additional option for OCSP in certpath),
+```ssl:handshake``` (TLS process handling) and ```respmgr``` (debug Response Manager which
+handles OCSP responses and other items)
+
+```aidl
+-Djava.security.debug="certpath ocsp" 
+-Djavax.net.debug="ssl:handshake,verbose,respmgr" 
+```
+
+Implementation Notes:
+- JDK OCSP Checker expects the TLS certificate to contain the full CA trust chain with the
+server cert first followed by intermediate and root. Just returning the server certificate without chain
+will produce a "OCSP is Disabled" message in debug trace of respmgr. Concatenate the server and CS certs into the
+certificate PEM file resolves the issue.   
+
+## Wireshark and traffic captures
+
+To be able to see the traffic flows between client and server, it can help to use Wireshark. However TLS is encrypted by default
+and traffic data is hidden. This can be resolved by enabling TLS Session key logging. See **References** for links
+to details articles and setup. 
+
+For the JDK, you can use the jSSLKeyLog agent to capture the TLS session key to a file and then configure Wireshark to
+read. Wireshark is then able to decrypt the traffic, which is required to see some packate details (for example, the
+OCSP Staple response details)
+```aidl
+-javaagent:$ROOTDIR/jSSLKeyLog.jar=jssl-key.log 
+```
+
+Similarly, it is also possible to trace the GRPC/Protobuf traffic by configuring the 
+Protobuf add-in Wireshark to use the Daml protobuf files. You may need to download Daml
+repo and Google base grpc protobuf files for this to work successfully.
+
+# Certificate Revocation Demonstration
+
+## TCP Socket, TLS OCSP and OCSP Stapling
+
+This example tests out Java JSSE implementation of OCSP and OCSP Stapling with or without client authentication. 
+The server allows the client to request and download the contents of a file in the server directory. The code 
+is available in:
+
+```aidl
+- sockets
+   - client - two clients (switch in the bash script) to connect and optionally authenticate to server
+   - server - server listener that accepts connects and requests for a file contents
+```
+
+This example includes:
+- create a sample PKI infrastructure
+- Run OCSP Responders for Root and Intermediate CAs
+- Run a TLS Server
+- Run a Client application to call server
+
+Sample Notes:
+- You need to download the JSSLKeyLog jar file if you wish to capture the TLS session keys for Wireshark analysis (see References section below)
+- The ```ocsp.enable=true``` parameter needs to be set in java.security properties file or in code. It is not an environment or system variable
+- Java JSSE Requires JKS format certification store files so make-certs imports the certificates into trust and key stores. There are simpler ways but this aligns with the overall sample PKI hierarchy.
+
+```aidl
+# Construct example two tier PKI
+./make-certs.sh
+
+# Create Root OCSP signing cert and run OCSP Responder
+./run-root-ocsp.sh
+
+# Construct Intermediate CA OCSP Certification and run responder 
+./run-ocsp.sh
+
+# Run a TLS Server
+# Optionally you can enable / disable TLS Mutual Authentication
+./run-tls-server.sh
+
+# Run a TLS Client
+# Note you can switch between standard TLS and Mutual TLS clients
+# Client should show contents of the test.txt file in the server directory 
+./run-tls-client.sh
+```
+
+What do the Java parameters do?
+```aidl
+# Enable TLS session key capture for Wireshark analysis
+-javaagent:$ROOTDIR/jSSLKeyLog.jar=jssl-key.log
+
+# Enable Java JSSE certpath and ocsp debug logging
+-Djava.security.debug="certpath ocsp" 
+# Enable Java JSSE TLS handshake debug logging
+-Djavax.net.debug="ssl:handshake" 
+
+# Enable OCSP Checking in Java JSSE - requires java security properties override or in code
+-Djava.security.properties=$ROOTDIR/java.security
+
+# Enable Revocation Checking
+-Dcom.sun.net.ssl.checkRevocation=true
+# Enable client side OCSP extensions 
+-Djdk.tls.client.enableStatusRequestExtension=true
+# Enable server side OCSP extensions 
+-Djdk.tls.server.enableStatusRequestExtension=true
+
+# Override Java JSSE default trust keystore  
+-Djavax.net.ssl.trustStore=$ROOTDIR/certs/intermediate/certs/local-truststore.jks
+# Password for trust keystore (and yes you should change it!) 
+-Djavax.net.ssl.trustStorePassword=changeit
+```
+
+## Daml Server-Side OCSP Certificate Revocation Checking
+
+The Daml Drivers allow OCSP (but currently not OCSP Stapling) to be enabled. This is enabled with the flag:
+
+```aidl
+--cert-revocation-checking true
+```
+
+NOTE: See next section for discussion on OCSP Stapling requirements 
+
+Sequence to setup and run environment
+```aidl
+# Ensure the following values are set to correct value in env.sh
+CLIENT_CERT_AUTH=TRUE
+LOCAL_JWT_SIGNING=TRUE
+DOCKER_COMPOSE=FALSE
+OCSP_CHECKING="--cert-revocation-checking true"
+
+./clean.sh
+./build.sh
+./run-docker.sh           # runs make-certs.sh and sets up Docker env
+./run-root-ocsp.sh
+./run-ocsp.sh
+./run-sandbox.sh
+./test-ocsp.sh
+```
+
+The final step demonstrates:
+- create a test cert
+- accessing the ledger and retrieving the Ledger API version
+- revoking the cert
+- access ledger again and see access failure from revoked cert
+
+## Daml Server-Side OCSP Stapling
+
+The default TLS Provider used by Daml is BoringSSL. This is a simplified implementation that
+reduces the TLS code base and removes a variety of features, particularly those that are not
+used frequently. This includes OCSP Stapling. It is possible to reconfigure Daml to use the installed JDK in preference to 
+Boring SSL but this currently requires a custom build of Daml API Server. 
+
+Two files need to be updated in the following directory in the Daml source code tree.
+
+```aidl
+ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/
+```
+
+Diff set for example code is:
+
+```aidl
+diff --git a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/OcspProperties.scala b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/OcspProperties.scala
+index bdbf2e4947..a227502522 100644
+--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/OcspProperties.scala
++++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/OcspProperties.scala
+@@ -11,11 +11,15 @@ object OcspProperties {
+
+   val CheckRevocationPropertySun: String = "com.sun.net.ssl.checkRevocation"
+   val CheckRevocationPropertyIbm: String = "com.ibm.jsse2.checkRevocation"
++  val ClientStatusRequestExtension: String = "jdk.tls.client.enableStatusRequestExtension"
++  val ServerStatusRequestExtension: String = "jdk.tls.server.enableStatusRequestExtension"
+   val EnableOcspProperty: String = "ocsp.enable"
+
+   def enableOcsp(): Unit = {
+     System.setProperty(CheckRevocationPropertySun, True)
+     System.setProperty(CheckRevocationPropertyIbm, True)
++    System.setProperty(ClientStatusRequestExtension, True)
++    System.setProperty(ServerStatusRequestExtension, True)
+     java.security.Security.setProperty(EnableOcspProperty, True)
+   }
+
+diff --git a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+index c61c21b1ed..1ddbb9a666 100644
+--- a/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
++++ b/ledger/ledger-api-common/src/main/scala/com/digitalasset/ledger/api/tls/TlsConfiguration.scala
+@@ -6,7 +6,7 @@ package com.daml.ledger.api.tls
+ import java.io.File
+
+ import io.grpc.netty.GrpcSslContexts
+-import io.netty.handler.ssl.{ClientAuth, SslContext}
++import io.netty.handler.ssl.{ClientAuth, SslContext, SslProvider, SslContextBuilder}
+
+ import scala.jdk.CollectionConverters._
+
+@@ -54,10 +54,11 @@ final case class TlsConfiguration(
+     if (enabled)
+       Some(
+         GrpcSslContexts
+-          .forServer(
+-            keyCertChainFileOrFail,
+-            keyFileOrFail,
+-          )
++          //.forServer(
++          //  keyCertChainFileOrFail,
++          //  keyFileOrFail,
++          //)
++          .configure(SslContextBuilder.forServer(keyCertChainFileOrFail, keyFileOrFail), SslProvider.JDK)
+           .trustManager(trustCertCollectionFile.orNull)
+           .clientAuth(clientAuth)
+           .protocols(if (protocols.nonEmpty) protocols.asJava else null)
+```
+
+after building and creating the custom jar file
+
+```aidl
+bazel build //ledger/daml-on-sql:daml-on-sql-binary_deploy.jar
+```
+
+Copy this to main directory of project. Update the run-sandbox.sh to enable full Stapling Support.
+
+The same set of command to the above OCSP test can be used to see OCSP Stapling.
+
+
+# References
+
+## JDK
+- [JDK PKI Programmers Guide](https://docs.oracle.com/javase/8/docs/technotes/guides/security/certpath/CertPathProgGuide.html)
+- [Oracle - Client-Driven OCSP and OCSP Stapling](https://docs.oracle.com/javase/8/docs/technotes/guides/security/jsse/ocsp.html)
+
+## Discussions on revocation and current state
+- [Revocation is broken](https://scotthelme.co.uk/revocation-is-broken/)
+- [Why Do Certificate Revocation Checking Mechanisms Never Work?](https://pfeifferszilard.hu/2020/09/09/why-do-certificate-revocation-checking-mechanisms-never-work.html)
+- [The Problem with OCSP Stapling and Must Staple and why Certificate Revocation is still broken](https://blog.hboeck.de/archives/886-The-Problem-with-OCSP-Stapling-and-Must-Staple-and-why-Certificate-Revocation-is-still-broken.html)
+- [Fixing Certificate Revocation](https://tersesystems.com/blog/2014/03/22/fixing-certificate-revocation/)
+- [SSL certificate revocation and how it is broken in practice](https://medium.com/@alexeysamoshkin/how-ssl-certificate-revocation-is-broken-in-practice-af3b63b9cb3)
+- [The current state of certificate revocation (CRLs, OCSP and OCSP Stapling)](https://www.maikel.pro/blog/current-state-certificate-revocation-crls-ocsp/)
+
+## OCSP Stapling, Must-Staple, CRLSet
+- [Everything You Need to Know About OCSP, OCSP Stapling & OCSP Must-Staple](https://www.thesslstore.com/blog/ocsp-ocsp-stapling-ocsp-must-staple/)
+- [On validation of Web X509 Certificates by TLS inception products](https://s3.amazonaws.com/ieeecs.cdn.csdl.content/trans/tq/5555/01/09110796.pdf?AWSAccessKeyId=ASIA2Z6GPE73HGDVU2RA&Expires=1614817088&Signature=H6J7bioUhIo%2FmfiWh5otfhVvoiI%3D&x-amz-security-token=IQoJb3JpZ2luX2VjELH%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FwEaCXVzLWVhc3QtMSJHMEUCIGfU2itZ%2B3ky3kr9vlXTwp2KKfVKmV5yPtGqmA8aC3R5AiEAkKWSmqIUTccmeL2DHElc86Ri2IOqN7CgqqhYDrNCD6Yq4AEIyf%2F%2F%2F%2F%2F%2F%2F%2F%2F%2FARAAGgw3NDI5MDg3MDA2NjIiDKb%2FrbzvOxcuCWxGQyq0AZ5sHVzDbxBoPOBrsDi7hs3fpiwnqKtiMJtuDQdr5kYwrouuEWIoZJjz%2FTwzuH9BjiVdOYXfT0rFhC6xk0y6CSH4sGakrSx7optIbrIKlum4ZC4%2BtEmva0bV8FI4BBVVsLJqSNd6rd5POPRvfLnr6nDAzipKjiPhH2%2F7VbTvhux%2FyEjEuVNxLORSV4alTsgWhTSoQFxJPEYuqlTrp%2BFxyjbN%2FyTkgYj0RtTw9SczxU5HZexh6zC8yoCCBjrgAfPVzMBs8%2BIS7eujPDfIeZHFt2UFzvcSUkUqNeC94bj1zJWz%2BCai0FvMGT7G1w5hPg7yo1kp2bkuZFx93gPaRPlCCdl4TivjuEh33dRkTcY3cb1ZJ%2FtT7Nz4bIFq0YiSg%2BkeY67M%2FwWvgJv95%2BqDI5lQQiGltd6OUT%2FJQPOWcBY3KDo0T1oHpcOdELE%2F03PiEutEK9Lto464t9s8uwso8Bs6YpWXBTENWJmnfFKE24vQU8dlBj1KA368w3%2Bjck%2FwB0BemUUxOv%2BOshh5myr%2BJ7m7Mz0EGexgsOUdmJO1vXlN)
+- [Venafi - OCSP Must-Staple: Revocation That Works](https://www.venafi.com/blog/ocsp-must-staple)  
+- [Is the web ready for OCSP Must-Staple?](https://blog.apnic.net/2019/01/15/is-the-web-ready-for-ocsp-must-staple/)
+
+## Wireshark Tracing
+- [Wireshark - TLS](https://wiki.wireshark.org/TLS)
+- [Analyzing gRPC messages using Wireshark](https://grpc.io/blog/wireshark/)
+- [Decrypting SSL traffic on Wireshark using jSSLKeyLog](https://community.microfocus.com/t5/ZENworks-Tips-Information/Decrypting-SSL-traffic-on-Wireshark-using-jSSLKeyLog/ta-p/2811103)
+
+
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+
+
+
+

--- a/Documentation/technote-postgresql.md
+++ b/Documentation/technote-postgresql.md
@@ -1,0 +1,142 @@
+[![DAML logo](https://daml.com/wp-content/uploads/2020/03/logo.png)](https://www.daml.com)
+
+[![Download](https://img.shields.io/github/release/digital-asset/daml.svg?label=Download)](https://docs.daml.com/getting-started/installation.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://github.com/digital-asset/daml/blob/master/LICENSE)
+
+# TechNote: Hardening PostgreSQL for TLS and default authentication options
+
+In this document we look at how to lock down access the PostgreSQL database connections. We use the PostgreSQL 12 Docker images as the 
+basis for this configuration. It also assumes you are using the full example reference app in this repo which implements a sample
+two-tier PKI CA hierarchy.
+
+The lockdown steps includes the following:
+
+- Docker startup
+- Enable TLS certicates on the server side
+- Initialisation of the PostgreSQL database on first use
+  - initialisation scripts
+  - Create a non-superuser user and separate database
+- Enable JDBC TLS and client certs
+  - Convert keys to DER format:
+  - JDBC connection parameters
+
+## Docker startup
+
+The PostgresQL Docker image is started as follows:
+
+```aidl
+docker run --name daml-postgres -d -p 5432:5432 \
+  -e POSTGRES_PASSWORD="ChangeDefaultPassword!" \
+  -e POSTGRES_HOST_AUTH_METHOD="scram-sha-256" \
+  -e POSTGRES_INITDB_ARGS="--auth-host=scram-sha-256 --auth-local=scram-sha-256" \
+  -v "$(pwd)/certs/server/certs/db.$DOMAIN.cert.pem:/var/lib/postgresql/db.$DOMAIN.cert.pem:ro" \
+  -v "$(pwd)/certs/server/private/db.$DOMAIN.key.pem:/var/lib/postgresql/db.$DOMAIN.key.pem:ro" \
+  -v "$(pwd)/certs/intermediate/certs/ca-chain.cert.pem:/var/lib/postgresql/ca-chain.crt:ro" \
+  -v "$(pwd)/pg-initdb:/docker-entrypoint-initdb.d:ro" \
+  postgres:12 \
+  -c ssl=on \
+  -c ssl_cert_file=/var/lib/postgresql/db.$DOMAIN.cert.pem \
+  -c ssl_key_file=/var/lib/postgresql/db.$DOMAIN.key.pem \
+  -c ssl_ca_file=/var/lib/postgresql/ca-chain.crt \
+  -c ssl_min_protocol_version="TLSv1.2" \
+  -c ssl_ciphers="HIGH:!MEDIUM:+3DES:!aNULL"
+```
+
+- POSTGRES_PASSWORD # Set the default super-administrative password
+- POSTGRES_HOST_AUTH_METHOD # The default authentication method. This can be ```trust``` but this bypasses all local authentication checks
+- POSTGRES_INITDB_ARGS # To support the changed authentication method we need to change the startup parameters to the DB
+- Several -v # mount various files into the Docker file system
+- ssl=on # Enable SSL for PostgresQL
+- ssl_cert_file # The public certificate for the database TLS connection
+- ssl_key_file # private key file
+- ssl_ca_file # the CA trust chain (root and intermediate)
+- ssl_min_protocol_version="TLSv1.2" # require minimum of TLS 1.2 protocol
+- ssl_ciphers="HIGH:!MEDIUM:+3DES:!aNULL" # Refuse certain weak ciphers for TLS
+
+## PostgresQL Initialization Script
+
+The PostgresQL Docker initialization script does the following:
+
+- Create a separate user (ledger) from the default super administration account (postgres)
+- Creates a separate database (ledger)
+- Allows all privileges to ledger user to new database (requires for Daml Ledgers to allow automated schema migrations)
+- Revokes permissions to default public schema
+- Creates a new pg_hba.conf file to restrict access to TLS (and optionally certificate authentication ```clientcert=1```) and reject
+non-TLS based connections. 
+- This also changes the default password hash method to scram-sha-256. Note that this may break come client libraries that do not support this
+password protection method.
+
+```aidl
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER ledger ENCRYPTED PASSWORD 'LedgerPassword!';
+    CREATE DATABASE ledger;
+    GRANT ALL PRIVILEGES ON DATABASE ledger TO ledger;
+    REVOKE ALL ON SCHEMA public FROM public;
+EOSQL
+
+echo "hostssl all all all scram-sha-256 clientcert=1\nhostnossl all postgres 0.0.0.0/0 reject" > $PGDATA/pg_hba.conf
+
+```
+## Enable TLS for Daml Drivers client
+
+To enable the Daml Driver-on-postgesql to connect to the database you need to set a JDBC connection URL
+
+```aidl
+# Normally one string but broken out for clarity
+ --sql-backend-jdbcurl 
+   "jdbc:postgresql://db.$DOMAIN/ledger?    # database hostname and default database
+   user=ledger&                             # User login
+   password=LedgerPassword!&                # Password
+   ssl=true&                                # Enable TLS Connection
+   sslmode=verify-full&                     # Require that full certificate chain is validated
+   sslrootcert=$ROOTDIR/certs/intermediate/certs/ca-chain.cert.pem&  # The PKI CA trust chain (root nad intermediate)
+   sslcert=$ROOTDIR/certs/client/client1.$DOMAIN.cert.der&  # Client Public key in DER format (see below)
+   sslkey=$ROOTDIR/certs/client/client1.$DOMAIN.key.der"    # Private key in DER format
+```
+
+As noted above the public / private key pair for the JDBC URL has to be provided in DER format. The PKI generates these in PEM format 
+so we need to convert using the following:
+
+```
+openssl x509 -in $ROOTDIR/certs/client/client1.$DOMAIN.cert.pem -inform pem -outform der -out $ROOTDIR/certs/client/client1.$DOMAIN.cert.der
+openssl pkcs8 -topk8 -inform PEM -outform DER -in $ROOTDIR/certs/client/client1.$DOMAIN.key.pem -out $ROOTDIR/certs/client/client1.$DOMAIN.key.der -nocrypt
+```
+This is done in make-certs.sh
+
+# Other comments on CIS Benchmark standard
+
+The CIS Standards also references many other settings that you should review for your specific deployment / environment. Many of 
+the recommendations are already implemented within Docker image. However, many of these are less relevant for Docker deployments
+
+- Hardening of the hosting server (accounts and file permissions)
+- Ensuring latest versions of packages and sourcing from the correct PostgresQL repos for your Linux distro
+- Various logging changes - some are applicable (logging of login sessions) and some depend on your preferred mechanism for 
+log ingestion (logging to file systems, etc)
+- Row level permissions and encryption - this will depend on your specific use case
+- Recommendations on variety of Postgres extension or plugins. Many of these are not provided by default in Docker image
+- Disabling various debug logging - most of which is disabled on Docker default image
+- Replication options
+
+
+As with all hardening standards, you may wish to review each control for applicability to your environment or deployment
+and document any exceptions or exemptions to the standard.
+
+# References
+
+- [CIS PostgresQL Benchmark](https://www.cisecurity.org/benchmark/postgresql/)
+- [Postgres Docker Documentation](https://hub.docker.com/_/postgres?source=post_page-----8e249f3c23dd----------------------&tab=description)
+- [Postgres pg_hba.conf documentation](https://www.postgresql.org/docs/current/auth-pg-hba-conf.html)
+- [Postgres JDBC Documentation](https://jdbc.postgresql.org/documentation/head/connect.html#ssl)
+- [Configurating Postgres for Mutual TLS](https://smallstep.com/hello-mtls/doc/server/postgresql)
+
+
+Copyright (c) 2021 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+SPDX-License-Identifier: Apache-2.0
+
+
+
+
+

--- a/clean.sh
+++ b/clean.sh
@@ -8,6 +8,7 @@ docker stop daml-envoyproxy
 docker rm daml-postgres
 docker rm daml-nginx
 docker rm daml-envoyproxy
+killall -9 openssl
 
 rm dist/*
 rm -rf certs
@@ -26,3 +27,5 @@ rm client-app/client.jar
 rm -rf client-app/target
 rm -rf client-app/project/project
 rm -rf client-app/project/target
+rm socket/client/*.class
+rm socket/server/*.class

--- a/client-app/src/main/scala/app/ClientApp.scala
+++ b/client-app/src/main/scala/app/ClientApp.scala
@@ -2,7 +2,6 @@ package app
 
 import java.io.File
 import java.io._
-
 import akka.actor.ActorSystem
 import com.daml.grpc.adapter.AkkaExecutionSequencerPool
 import com.daml.ledger.api.refinements.ApiTypes.ApplicationId
@@ -13,11 +12,12 @@ import com.daml.ledger.client.configuration.LedgerIdRequirement
 import com.typesafe.scalalogging.StrictLogging
 import io.grpc.netty.GrpcSslContexts
 
-
+import java.lang.System._
 import scala.concurrent.Await
 import scala.concurrent.ExecutionContext
 import scala.concurrent.Future
 import scala.concurrent.duration._
+import io.netty.handler.ssl.{SslProvider, SslContextBuilder}
 
 object ClientApp extends App with StrictLogging {
   private val ledgerHost = args(0)
@@ -41,6 +41,7 @@ object ClientApp extends App with StrictLogging {
     new AkkaExecutionSequencerPool("clientPool")(asys)
   private implicit val ec: ExecutionContext = asys.dispatcher
 
+
   private def shutdown(): Unit = {
     logger.info("Shutting down...")
     Await.result(asys.terminate(), 10.seconds)
@@ -50,7 +51,8 @@ object ClientApp extends App with StrictLogging {
   private val applicationId = ApplicationId("TlsDemo")
 
   val sslContext = GrpcSslContexts
-    .forClient()
+    //.forClient()
+    .configure(SslContextBuilder.forClient(), SslProvider.JDK)
     .keyManager(clientCert, clientKey)
     .trustManager(caCert)
     .build()
@@ -80,9 +82,10 @@ object ClientApp extends App with StrictLogging {
       val sw = new StringWriter
       e.printStackTrace(new PrintWriter(sw))
       logger.error(sw.toString)
+      exit(1)
     }
   }
 
   shutdown()
-  System.exit(0)
+  exit(0)
 }

--- a/edge-tls.yaml
+++ b/edge-tls.yaml
@@ -28,8 +28,8 @@ static_resources:
         common_tls_context:
             alpn_protocols: "h2"
             tls_certificates:
-            - certificate_chain: { filename: "/data/certs/server/certs/envoy.acme.com.cert.pem" }
-              private_key: { filename: "/data/certs/server/private/envoy.acme.com.key.pem" }
+            - certificate_chain: { filename: "/etc/ssl/server.crt" }
+              private_key: { filename: "/etc/ssl/server.key" }
   clusters:
   - name: ledger.acme.com_6865
     connect_timeout: 25s
@@ -43,7 +43,7 @@ static_resources:
         - endpoint:
             address:
               socket_address:
-                address: ledger.acme.com
+                address: docker.for.mac.localhost
                 port_value: 6865
     transport_socket:
       name: envoy.transport_sockets.tls
@@ -52,11 +52,11 @@ static_resources:
         sni: ledger.acme.com
         common_tls_context: 
           tls_certificates:
-            certificate_chain: { "filename": "/data/certs/client/client1.acme.com.cert.pem" }
-            private_key: { "filename": "/data/certs/client/client1.acme.com.key.pem" }
+            certificate_chain: { "filename": "/etc/ssl/client.crt" }
+            private_key: { "filename": "/etc/ssl/client.key" }
           validation_context:
             match_subject_alt_names:
             - exact: "ledger.acme.com"
             trusted_ca:
-              filename: /data/certs/intermediate/certs/ca-chain.cert.pem
+              filename: /etc/ssl/certs/ca-chain.crt
 

--- a/env.sh
+++ b/env.sh
@@ -4,6 +4,9 @@
 
 ROOTDIR=$PWD
 
+# Switch to openjdk 11
+export PATH="/usr/local/opt/openjdk@11/bin:$PATH"
+
 #The following options define whether to enable client certificate authentication. Please uncomment one
 #CLIENT_CERT_AUTH=FALSE
 CLIENT_CERT_AUTH=TRUE
@@ -12,10 +15,14 @@ CLIENT_CERT_AUTH=TRUE
 #LOCAL_JWT_SIGNING=FALSE
 LOCAL_JWT_SIGNING=TRUE
 
-DOCKER_COMPOSE=TRUE
-#DOCKER_COMPOSE=FALSE
+#DOCKER_COMPOSE=TRUE
+DOCKER_COMPOSE=FALSE
 
-DOCKER_IMAGE="digitalasset/daml-sdk:1.5.0"
+# OCSP Checking
+OCSP_CHECKING=""
+#OCSP_CHECKING="--cert-revocation-checking true"
+
+DOCKER_IMAGE="digitalasset/daml-sdk:1.10.0"
 
 # The Ledger ID is used to bootstrap the system with a known identity. This is a random UUID and should be unique to each ledger instance.
 #

--- a/intermediate-ca.cnf.sample
+++ b/intermediate-ca.cnf.sample
@@ -103,6 +103,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2562
 
 [ usr_cert ]
 # Extensions for client certificates (`man x509v3_config`).
@@ -114,7 +115,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer
 keyUsage = critical, nonRepudiation, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth, emailProtection
-crlDistributionPoints = URI:http://crl.<DOMAIN>/intermediate.crl.pem
+#crlDistributionPoints = URI:http://crl.<DOMAIN>/intermediate.crl.pem
 authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2560
 
 [ server_cert ]
@@ -127,7 +128,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid,issuer:always
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
-crlDistributionPoints = URI:http://crl.<DOMAIN>/intermediate.crl.pem
+#crlDistributionPoints = URI:http://crl.<DOMAIN>/intermediate.crl.pem
 authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2560
 
 [ sign_cert ]
@@ -135,7 +136,7 @@ authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2560
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
 keyUsage = critical, digitalSignature
-crlDistributionPoints = URI:http://crl.<DOMAIN>/intermediate.crl.pem
+#crlDistributionPoints = URI:http://crl.<DOMAIN>/intermediate.crl.pem
 authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2560
 
 [ crl_ext ]

--- a/java.security
+++ b/java.security
@@ -1,0 +1,2 @@
+ocsp.enable=true
+

--- a/make-certs.sh
+++ b/make-certs.sh
@@ -258,6 +258,7 @@ create_db() {
   openssl verify -CAfile $ROOTDIR/certs/intermediate/certs/ca-chain.cert.pem \
       $ROOTDIR/certs/server/certs/db.$DOMAIN.cert.pem
 
+  cat $ROOTDIR/certs/server/certs/db.$DOMAIN.cert.pem $ROOTDIR/certs/intermediate/certs/ca-chain.cert.pem > $ROOTDIR/certs/server/certs/db-chain.$DOMAIN.cert.pem
 }
 
 create_auth() {
@@ -320,6 +321,10 @@ create_client() {
   # Validate cert is correct
   openssl verify -CAfile $ROOTDIR/certs/intermediate/certs/ca-chain.cert.pem \
       $ROOTDIR/certs/client/client1.$DOMAIN.cert.pem
+
+  openssl x509 -in $ROOTDIR/certs/client/client1.$DOMAIN.cert.pem -inform pem -outform der -out $ROOTDIR/certs/client/client1.$DOMAIN.cert.der
+  openssl pkcs8 -topk8 -inform PEM -outform DER -in $ROOTDIR/certs/client/client1.$DOMAIN.key.pem -out $ROOTDIR/certs/client/client1.$DOMAIN.key.der -nocrypt
+ 
 }
 
 revoke_client() {
@@ -355,6 +360,4 @@ create_auth
 verify_server
 
 create_client
-
-
 

--- a/pg-initdb/init-userdb.sh
+++ b/pg-initdb/init-userdb.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" <<-EOSQL
+    CREATE USER ledger ENCRYPTED PASSWORD 'LedgerPassword!';
+    CREATE DATABASE ledger;
+    GRANT ALL PRIVILEGES ON DATABASE ledger TO ledger;
+    REVOKE ALL ON SCHEMA public FROM public;
+EOSQL
+
+echo "hostssl all all all scram-sha-256 clientcert=1" >  $PGDATA/pg_hba.conf
+echo "hostnossl all postgres 0.0.0.0/0 reject" >> $PGDATA/pg_hba.conf

--- a/root-ca.cnf.sample
+++ b/root-ca.cnf.sample
@@ -93,15 +93,17 @@ emailAddress_default            =
 # Extensions for a typical CA (`man x509v3_config`).
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
-basicConstraints = critical, CA:true
+basicConstraints = critical, CA:TRUE
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2562
 
 [ v3_intermediate_ca ]
 # Extensions for a typical intermediate CA (`man x509v3_config`).
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
-basicConstraints = critical, CA:true, pathlen:0
+basicConstraints = critical, CA:TRUE, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+authorityInfoAccess = OCSP;URI:http://ocsp.<DOMAIN>:2562
 
 [ usr_cert ]
 # Extensions for client certificates (`man x509v3_config`).

--- a/run-docker.sh
+++ b/run-docker.sh
@@ -17,7 +17,24 @@ fi
 
 docker stop daml-postgres
 docker rm daml-postgres
-docker run --name daml-postgres -d -p 5432:5432 -e POSTGRES_PASSWORD="ChangeDefaultPassword!" -e POSTGRES_HOST_AUTH_METHOD=trust -v "$(pwd)/certs/server/certs/db.$DOMAIN.cert.pem:/var/lib/postgresql/db.$DOMAIN.cert.pem:ro" -v "$(pwd)/certs/server/private/db.$DOMAIN.key.pem:/var/lib/postgresql/db.$DOMAIN.key.pem:ro" -v "$(pwd)/certs/intermediate/certs/ca-chain.cert.pem:/var/lib/postgresql/ca-chain.crt:ro" postgres:12 -c ssl=on -c ssl_cert_file=/var/lib/postgresql/db.$DOMAIN.cert.pem -c ssl_key_file=/var/lib/postgresql/db.$DOMAIN.key.pem -c ssl_ca_file=/var/lib/postgresql/ca-chain.crt -c ssl_min_protocol_version="TLSv1.2" -c ssl_ciphers="HIGH:!MEDIUM:+3DES:!aNULL"
+docker run --name daml-postgres -d -p 5432:5432 \
+  -e POSTGRES_PASSWORD="ChangeDefaultPassword!" \
+  -e POSTGRES_HOST_AUTH_METHOD="scram-sha-256" \
+  -e POSTGRES_INITDB_ARGS="--auth-host=scram-sha-256 --auth-local=scram-sha-256" \
+  -v "$(pwd)/certs/server/certs/db-chain.$DOMAIN.cert.pem:/var/lib/postgresql/db.$DOMAIN.cert.pem:ro" \
+  -v "$(pwd)/certs/server/private/db.$DOMAIN.key.pem:/var/lib/postgresql/db.$DOMAIN.key.pem:ro" \
+  -v "$(pwd)/certs/intermediate/certs/ca-chain.cert.pem:/var/lib/postgresql/ca-chain.crt:ro" \
+  -v "$(pwd)/pg-initdb:/docker-entrypoint-initdb.d:ro" \
+  postgres:12 \
+  -c ssl=on \
+  -c ssl_cert_file=/var/lib/postgresql/db.$DOMAIN.cert.pem \
+  -c ssl_key_file=/var/lib/postgresql/db.$DOMAIN.key.pem \
+  -c ssl_ca_file=/var/lib/postgresql/ca-chain.crt \
+  -c ssl_min_protocol_version="TLSv1.2" \
+  -c ssl_ciphers="HIGH:!MEDIUM:+3DES:!aNULL"
+
+# Old version
+#docker run --name daml-postgres -d -p 5432:5432 -e POSTGRES_PASSWORD="ChangeDefaultPassword!" -e POSTGRES_HOST_AUTH_METHOD=trust -v "$(pwd)/certs/server/certs/db.$DOMAIN.cert.pem:/var/lib/postgresql/db.$DOMAIN.cert.pem:ro" -v "$(pwd)/certs/server/private/db.$DOMAIN.key.pem:/var/lib/postgresql/db.$DOMAIN.key.pem:ro" -v "$(pwd)/certs/intermediate/certs/ca-chain.cert.pem:/var/lib/postgresql/ca-chain.crt:ro" postgres:12 -c ssl=on -c ssl_cert_file=/var/lib/postgresql/db.$DOMAIN.cert.pem -c ssl_key_file=/var/lib/postgresql/db.$DOMAIN.key.pem -c ssl_ca_file=/var/lib/postgresql/ca-chain.crt -c ssl_min_protocol_version="TLSv1.2" -c ssl_ciphers="HIGH:!MEDIUM:+3DES:!aNULL"
 
 # Run NGINX
 

--- a/run-root-ocsp.sh
+++ b/run-root-ocsp.sh
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Copyright (c) 2020 Digital Asset (Switzerland) GmbH and/or its affiliates. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+
+set -euo pipefail
+
+# https://jamielinux.com/docs/openssl-certificate-authority/online-certificate-status-protocol.html
+# https://www.shellhacks.com/create-csr-openssl-without-prompt-non-interactive/
+# https://akshayranganath.github.io/OCSP-Validation-With-Openssl/
+# https://medium.com/@KentaKodashima/generate-pem-keys-with-openssl-on-macos-ecac55791373
+
+# OpenSSL testing of certs: https://www.feistyduck.com/library/openssl-cookbook/online/ch-testing-with-openssl.html
+
+create_CRL() {
+  # Create CRL for certificate
+
+  openssl ca -config $ROOTDIR/certs/root/openssl.cnf \
+      -gencrl -out $ROOTDIR/certs/rot/crl/root.crl.pem
+
+  # Check CRL
+  openssl crl -in $ROOTDIR/certs/root/crl/root.crl.pem -noout -text
+}
+
+create_ocsp_key() {
+  echo "Creating OCSP Server Key"
+
+  # Create OCSP 
+  openssl genrsa \
+      -out $ROOTDIR/certs/root/private/root-ocsp.$DOMAIN.key.pem 4096
+
+  openssl req -config $ROOTDIR/certs/root/openssl.cnf -new -sha256 \
+      -subj "/C=US/ST=New York/O=$DOMAIN_NAME/CN=root-ocsp.$DOMAIN" \
+      -key $ROOTDIR/certs/root/private/root-ocsp.$DOMAIN.key.pem \
+      -out $ROOTDIR/certs/root/certs/root-ocsp.$DOMAIN.csr.pem
+
+  openssl ca -batch -config $ROOTDIR/certs/root/openssl.cnf \
+      -extensions ocsp -days 375 -notext -md sha256 \
+      -in $ROOTDIR/certs/root/certs/root-ocsp.$DOMAIN.csr.pem \
+      -out $ROOTDIR/certs/root/certs/root-ocsp.$DOMAIN.cert.pem
+
+  # Validate extensions
+  openssl x509 -noout -text \
+      -in $ROOTDIR/certs/root/certs/root-ocsp.$DOMAIN.cert.pem
+}
+
+start_ocsp() {
+  echo "Starting OCSP responder"
+
+  cd $ROOTDIR
+
+  # Note that this is set to only listen for one request and then terminate
+  openssl ocsp -port 2562 -text \
+    -index "$(pwd)/certs/root/index.txt" \
+    -CA "$(pwd)/certs/root/certs/ca.cert.pem" \
+    -rkey "$(pwd)/certs/root/private/root-ocsp.$DOMAIN.key.pem" \
+    -rsigner "$(pwd)/certs/root/certs/root-ocsp.$DOMAIN.cert.pem" \
+    -nrequest 1 &
+
+  sleep 3
+}
+start_ocsp_longrunning() {
+  echo "Starting root OCSP responder"
+
+  cd $ROOTDIR 
+
+  # Note that this is set to only listen for one request and then terminate
+  x=1
+  while [ $x -le 20 ]
+  do
+    openssl ocsp -port 2562 -text \
+      -index "$(pwd)/certs/root/index.txt" \
+      -CA "$(pwd)/certs/root/certs/ca.cert.pem" \
+      -rkey "$(pwd)/certs/root/private/root-ocsp.$DOMAIN.key.pem" \
+      -rsigner "$(pwd)/certs/root/certs/root-ocsp.$DOMAIN.cert.pem" \
+      -multi 1 \
+      -timeout 5
+
+    x=$(( $x + 1 ))
+  done
+
+}
+
+check_ocsp_response() {
+  echo "Check OCSP response"
+  openssl ocsp -CAfile "$ROOTDIR/certs/root/certs/ca.cert.pem" \
+      -url http://127.0.0.1:2562 -resp_text \
+      -issuer "$ROOTDIR/certs/root/certs/ca.cert.pem" \
+      -cert "$ROOTDIR/certs/intermediate/certs/intermediate.cert.pem"
+}
+
+# On MacOS use brew installed openssl 1.1.1
+export PATH=/usr/local/opt/openssl/bin:$PATH
+
+source env.sh
+
+export ROOTDIR=$PWD
+cd $ROOTDIR
+
+if [ ! -d certs ] ; then
+ echo "ERROR: You need to create PKI CA hierarchy first!"
+ exit
+fi
+
+if [ ! -f $ROOTDIR/certs/root/private/root-ocsp.$DOMAIN.key.pem ]; then
+   create_ocsp_key
+fi
+
+start_ocsp
+check_ocsp_response
+
+start_ocsp_longrunning
+
+
+

--- a/run-sandbox.sh
+++ b/run-sandbox.sh
@@ -41,10 +41,26 @@ if [ ! -f daml-on-sql-1.10.0.jar ]; then
    wget https://github.com/digital-asset/daml/releases/download/v1.10.0/daml-on-sql-1.10.0.jar
 fi
 
-java -jar daml-on-sql-1.10.0.jar \
+OCSP_STAPLE="TRUE"
+if [ "$OCSP_STAPLE" == "TRUE" ] ; then
+   export JDK_JAVA_OPTIONS="-javaagent:$ROOTDIR/jSSLKeyLog.jar=server.log -Djava.security.properties=$ROOTDIR/java.security -Dcom.sun.net.ssl.checkRevocation=true -Djdk.tls.client.enableStatusRequestExtension=true -Djdk.tls.server.enableStatusRequestExtension=true -Djava.security.debug='certpath ocsp' -Djavax.net.debug='ssl:handshake,verbose,respmgr'"
+   wget https://github.com/jsslkeylog/jsslkeylog/releases/download/v1.3.0/jSSLKeyLog-1.3.zip -O jSSLKeyLog-1.3.zip
+   unzip -o jSSLKeyLog-1.3.zip jSSLKeyLog.jar
+   JAR="daml-on-sql-binary_deploy.jar"
+   if [ ! -f $JAR ] ; then
+      echo "WARNING: OCSP depends on a custom build of daml-on-sql to use JDK SSLProvider"
+      exit 1
+   fi
+else
+   JAR="daml-on-sql-1.10.0.jar"
+fi
+
+echo $JDK_JAVA_OPTIONS
+
+java -jar $JAR \
  ./dist/ex-secure-daml-infra-0.0.1.dar \
  --client-auth $CLIENT_CERT_AUTH_PARAM \
- --sql-backend-jdbcurl "jdbc:postgresql://localhost/postgres?user=postgres&password=ChangeDefaultPassword!&ssl=on" \
+ --sql-backend-jdbcurl "jdbc:postgresql://db.$DOMAIN/ledger?user=ledger&password=LedgerPassword!&ssl=true&sslmode=verify-full&sslrootcert=$ROOTDIR/certs/intermediate/certs/ca-chain.cert.pem&sslcert=$ROOTDIR/certs/client/client1.$DOMAIN.cert.der&sslkey=$ROOTDIR/certs/client/client1.$DOMAIN.key.der" \
  $SIGNER_URL \
  --log-level DEBUG \
  --ledgerid $LEDGER_ID \

--- a/run-tls-client.sh
+++ b/run-tls-client.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+source env.sh
+
+cd sockets/client
+
+if [ ! -f SSLSocketClient.class ] ; then
+  javac *.java
+fi
+
+java -javaagent:$ROOTDIR/jSSLKeyLog.jar=jssl-key.log  -Djava.security.debug="certpath ocsp" -Dcom.sun.net.ssl.checkRevocation=true -Djdk.tls.client.enableStatusRequestExtension=true -Djdk.tls.server.enableStatusRequestExtension=true -Djavax.net.debug="ssl:handshake" -Djava.security.properties=$ROOTDIR/java.security -Djavax.net.ssl.trustStore=$ROOTDIR/certs/intermediate/certs/local-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit SSLSocketClientWithClientAuth localhost 6866 $ROOTDIR/certs/client/client1.$DOMAIN.jks /test.txt
+
+#java -javaagent:$ROOTDIR/jSSLKeyLog.jar=jssl-key.log  -Djava.security.debug="certpath ocsp" -Dcom.sun.net.ssl.checkRevocation=true -Djdk.tls.client.enableStatusRequestExtension=true -Djdk.tls.server.enableStatusRequestExtension=false -Djavax.net.debug="ssl:handshake" -Djava.security.properties=$ROOTDIR/java.security -Djavax.net.ssl.trustStore=$ROOTDIR/certs/intermediate/certs/local-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit SSLSocketClient localhost 6866 /test.txt

--- a/run-tls-server.sh
+++ b/run-tls-server.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+source env.sh
+
+create_jks_truststore() {
+  keytool -import -alias root -file "$ROOTDIR/certs/root/certs/ca.cert.pem" -keystore "$ROOTDIR/certs/intermediate/certs/local-truststore.jks" -storepass changeit -noprompt
+  keytool -import -alias intermediate -file "$ROOTDIR/certs/intermediate/certs/intermediate.cert.pem" -keystore "$ROOTDIR/certs/intermediate/certs/local-truststore.jks" -storepass changeit -noprompt
+  keytool -list -keystore "$ROOTDIR/certs/intermediate/certs/local-truststore.jks" -storepass changeit
+}
+
+create_jks_client_keystore() {
+  cd $ROOTDIR
+  cat "$ROOTDIR/certs/client/client1.acme.com.cert.pem" "$ROOTDIR/certs/intermediate/certs/intermediate.cert.pem" "$ROOTDIR/certs/root/certs/ca.cert.pem" > import.pem
+  echo "changeit" | openssl pkcs12 -export -password stdin -in import.pem -inkey "$ROOTDIR/certs/client/client1.acme.com.key.pem" -name client > client.p12
+  echo "changeit" | keytool -importkeystore -srckeypass changeit -destkeypass changeit -noprompt -srckeystore client.p12 -destkeystore "$ROOTDIR/certs/client/client1.acme.com.jks" -srcstoretype pkcs12 -alias client -storepass changeit
+  keytool -list -keystore "$ROOTDIR/certs/client/client1.acme.com.jks" -storepass changeit
+}
+
+create_jks_server_keystore() {
+  cd $ROOTDIR
+  cat "$ROOTDIR/certs/server/certs/ledger.acme.com.cert.pem" "$ROOTDIR/certs/intermediate/certs/intermediate.cert.pem" "$ROOTDIR/certs/root/certs/ca.cert.pem" > import.pem
+  echo "changeit" | openssl pkcs12 -export -password stdin -in import.pem -inkey "$ROOTDIR/certs/server/private/ledger.acme.com.key.pem" -name server > server.p12
+  echo "changeit" | keytool -importkeystore -srckeypass changeit -destkeypass changeit -noprompt -srckeystore server.p12 -destkeystore "$ROOTDIR/certs/server/certs/ledger.acme.com.jks" -srcstoretype pkcs12 -alias server -storepass changeit
+  keytool -list -keystore "$ROOTDIR/certs/server/certs/ledger.acme.com.jks" -storepass changeit
+}
+
+create_jks_truststore
+create_jks_client_keystore
+create_jks_server_keystore
+
+cd sockets/server
+
+if [ ! -f ClassFileServer.class ] ; then
+  javac *.java
+fi
+
+java -javaagent:$ROOTDIR/jSSLKeyLog.jar=jssl-key.log -Djava.security.debug="certpath ocsp" -Djavax.net.debug="ssl:handshake,verbose,respmgr" -Dcom.sun.net.ssl.checkRevocation=true -Djdk.tls.client.enableStatusRequestExtension=true -Djdk.tls.server.enableStatusRequestExtension=true -Djava.security.properties=$ROOTDIR/java.security -Djavax.net.ssl.trustStore=$ROOTDIR/certs/intermediate/certs/local-truststore.jks -Djavax.net.ssl.trustStorePassword=changeit ClassFileServer 6866 $ROOTDIR/sockets/server $ROOTDIR/certs/server/certs/ledger.$DOMAIN.jks true

--- a/sockets/client/SSLSocketClient.java
+++ b/sockets/client/SSLSocketClient.java
@@ -1,0 +1,114 @@
+/*
+ *
+ * Copyright (c) 1994, 2004, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * -Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of Oracle nor the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
+ * OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed, licensed or
+ * intended for use in the design, construction, operation or
+ * maintenance of any nuclear facility.
+ */
+
+import java.net.*;
+import java.io.*;
+import javax.net.ssl.*;
+
+/*
+ * This example demostrates how to use a SSLSocket as client to
+ * send a HTTP request and get response from an HTTPS server.
+ * It assumes that the client is not behind a firewall
+ */
+
+public class SSLSocketClient {
+
+    public static void main(String[] args) throws Exception {
+        try {
+            SSLSocketFactory factory =
+                (SSLSocketFactory)SSLSocketFactory.getDefault();
+            SSLSocket socket =
+                (SSLSocket)factory.createSocket("localhost", 6666);
+
+            /*
+             * send http request
+             *
+             * Before any application data is sent or received, the
+             * SSL socket will do SSL handshaking first to set up
+             * the security attributes.
+             *
+             * SSL handshaking can be initiated by either flushing data
+             * down the pipe, or by starting the handshaking by hand.
+             *
+             * Handshaking is started manually in this example because
+             * PrintWriter catches all IOExceptions (including
+             * SSLExceptions), sets an internal error flag, and then
+             * returns without rethrowing the exception.
+             *
+             * Unfortunately, this means any error messages are lost,
+             * which caused lots of confusion for others using this
+             * code.  The only way to tell there was an error is to call
+             * PrintWriter.checkError().
+             */
+            socket.startHandshake();
+
+            PrintWriter out = new PrintWriter(
+                                  new BufferedWriter(
+                                  new OutputStreamWriter(
+                                  socket.getOutputStream())));
+
+            out.println("GET /test.txt HTTP/1.0");
+            out.println();
+            out.flush();
+
+            /*
+             * Make sure there were no surprises
+             */
+            if (out.checkError())
+                System.out.println(
+                    "SSLSocketClient:  java.io.PrintWriter error");
+
+            /* read response */
+            BufferedReader in = new BufferedReader(
+                                    new InputStreamReader(
+                                    socket.getInputStream()));
+
+            String inputLine;
+            while ((inputLine = in.readLine()) != null)
+                System.out.println(inputLine);
+
+            in.close();
+            out.close();
+            socket.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/sockets/client/SSLSocketClientWithClientAuth.java
+++ b/sockets/client/SSLSocketClientWithClientAuth.java
@@ -1,0 +1,157 @@
+/*
+ *
+ * Copyright (c) 1994, 2004, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * -Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of Oracle nor the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
+ * OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed, licensed or
+ * intended for use in the design, construction, operation or
+ * maintenance of any nuclear facility.
+ */
+
+
+import java.net.*;
+import java.io.*;
+import javax.net.ssl.*;
+import javax.security.cert.X509Certificate;
+import java.security.KeyStore;
+
+/*
+ * This example shows how to set up a key manager to do client
+ * authentication if required by server.
+ *
+ * This program assumes that the client is not inside a firewall.
+ * The application can be modified to connect to a server outside
+ * the firewall by following SSLSocketClientWithTunneling.java.
+ */
+public class SSLSocketClientWithClientAuth {
+
+    public static void main(String[] args) throws Exception {
+        String host = null;
+        int port = -1;
+        String certFile = null;
+        String path = null;
+        for (int i = 0; i < args.length; i++)
+            System.out.println(args[i]);
+
+        if (args.length < 4) {
+            System.out.println(
+                "USAGE: java SSLSocketClientWithClientAuth " +
+                "host port cert-jks requestedfilepath");
+            System.exit(-1);
+        }
+
+        try {
+            host = args[0];
+            port = Integer.parseInt(args[1]);
+            certFile = args[2];
+            path = args[3];
+        } catch (IllegalArgumentException e) {
+             System.out.println("USAGE: java SSLSocketClientWithClientAuth " +
+                 "host port cert-jks requestedfilepath");
+             System.exit(-1);
+        }
+
+        try {
+
+            /*
+             * Set up a key manager for client authentication
+             * if asked by the server.  Use the implementation's
+             * default TrustStore and secureRandom routines.
+             */
+            SSLSocketFactory factory = null;
+            try {
+                SSLContext ctx;
+                KeyManagerFactory kmf;
+                KeyStore ks;
+                char[] passphrase = "changeit".toCharArray();
+
+                ctx = SSLContext.getInstance("TLS");
+                kmf = KeyManagerFactory.getInstance("SunX509");
+                ks = KeyStore.getInstance("JKS");
+
+                ks.load(new FileInputStream(certFile), passphrase);
+
+                kmf.init(ks, passphrase);
+                ctx.init(kmf.getKeyManagers(), null, null);
+
+                factory = ctx.getSocketFactory();
+            } catch (Exception e) {
+                throw new IOException(e.getMessage());
+            }
+
+            SSLSocket socket = (SSLSocket)factory.createSocket(host, port);
+
+            //#String[] protocols = new String[] {"TLSv1.2"};
+            //socket.setEnabledProtocols(protocols);
+
+            /*
+             * send http request
+             *
+             * See SSLSocketClient.java for more information about why
+             * there is a forced handshake here when using PrintWriters.
+             */
+            socket.startHandshake();
+
+            PrintWriter out = new PrintWriter(
+                                  new BufferedWriter(
+                                  new OutputStreamWriter(
+                                  socket.getOutputStream())));
+            out.println("GET /" + path + " HTTP/1.0");
+            out.println();
+            out.flush();
+
+            /*
+             * Make sure there were no surprises
+             */
+            if (out.checkError())
+                System.out.println(
+                    "SSLSocketClient: java.io.PrintWriter error");
+
+            /* read response */
+            BufferedReader in = new BufferedReader(
+                                    new InputStreamReader(
+                                    socket.getInputStream()));
+
+            String inputLine;
+
+            while ((inputLine = in.readLine()) != null)
+                System.out.println(inputLine);
+
+            in.close();
+            out.close();
+            socket.close();
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/sockets/server/ClassFileServer.java
+++ b/sockets/server/ClassFileServer.java
@@ -1,0 +1,180 @@
+/*
+ *
+ * Copyright (c) 1994, 2004, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * -Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of Oracle nor the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
+ * OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed, licensed or
+ * intended for use in the design, construction, operation or
+ * maintenance of any nuclear facility.
+ */
+
+import java.io.*;
+import java.net.*;
+import java.security.KeyStore;
+import javax.net.*;
+import javax.net.ssl.*;
+import javax.security.cert.X509Certificate;
+
+/* ClassFileServer.java -- a simple file server that can server
+ * Http get request in both clear and secure channel
+ *
+ * The ClassFileServer implements a ClassServer that
+ * reads files from the file system. See the
+ * doc for the "Main" method for how to run this
+ * server.
+ */
+
+public class ClassFileServer extends ClassServer {
+
+    private String docroot;
+    private String certFile;
+
+    private static int DefaultServerPort = 2001;
+
+    /**
+     * Constructs a ClassFileServer.
+     *
+     * @param path the path where the server locates files
+     */
+    public ClassFileServer(ServerSocket ss, String docroot, String certFile) throws IOException
+    {
+        super(ss);
+        this.docroot = docroot;
+        this.certFile = certFile;
+    }
+
+    /**
+     * Returns an array of bytes containing the bytes for
+     * the file represented by the argument <b>path</b>.
+     *
+     * @return the bytes for the file
+     * @exception FileNotFoundException if the file corresponding
+     * to <b>path</b> could not be loaded.
+     */
+    public byte[] getBytes(String path)
+        throws IOException
+    {
+        System.out.println("reading: " + docroot + File.separator + path);
+        File f = new File(docroot + File.separator + path);
+        int length = (int)(f.length());
+        if (length == 0) {
+            throw new IOException("File length is zero: " + path);
+        } else {
+            FileInputStream fin = new FileInputStream(f);
+            DataInputStream in = new DataInputStream(fin);
+
+            byte[] bytecodes = new byte[length];
+            in.readFully(bytecodes);
+            return bytecodes;
+        }
+    }
+
+    /**
+     * Main method to create the class server that reads
+     * files. This takes two command line arguments, the
+     * port on which the server accepts requests and the
+     * root of the path. To start up the server: <br><br>
+     *
+     * <code>   java ClassFileServer <port> <path>
+     * </code><br><br>
+     *
+     * <code>   new ClassFileServer(port, docroot);
+     * </code>
+     */
+    public static void main(String args[])
+    {
+        System.out.println(
+            "USAGE: java ClassFileServer port docroot server-jks-file [true]");
+        System.out.println("");
+        System.out.println(
+            "If the fourth argument is true,it will require\n" +
+            "client authentication as well.");
+
+        int port = DefaultServerPort;
+        String docroot = "";
+        String certFile = "";
+
+        if (args.length >= 1) {
+            port = Integer.parseInt(args[0]);
+        }
+
+        if (args.length >= 2) {
+            docroot = args[1];
+        }
+        String type = "TLS";
+        if (args.length >= 3) {
+            certFile = args[2];
+        }
+        try {
+            ServerSocketFactory ssf =
+                ClassFileServer.getServerSocketFactory(type, certFile);
+            ServerSocket ss = ssf.createServerSocket(port);
+            if (args.length >= 4 && args[3].equals("true")) {
+                ((SSLServerSocket)ss).setNeedClientAuth(true);
+            }
+            new ClassFileServer(ss, docroot, certFile);
+        } catch (IOException e) {
+            System.out.println("Unable to start ClassServer: " +
+                               e.getMessage());
+            e.printStackTrace();
+        }
+    }
+
+    private static ServerSocketFactory getServerSocketFactory(String type, String certFile) {
+        if (type.equals("TLS")) {
+            SSLServerSocketFactory ssf = null;
+            try {
+                // set up key manager to do server authentication
+                SSLContext ctx;
+                KeyManagerFactory kmf;
+                KeyStore ks;
+                char[] passphrase = "changeit".toCharArray();
+
+                ctx = SSLContext.getInstance("TLS");
+                kmf = KeyManagerFactory.getInstance("SunX509");
+                ks = KeyStore.getInstance("JKS");
+
+                ks.load(new FileInputStream(certFile), passphrase);
+                kmf.init(ks, passphrase);
+                ctx.init(kmf.getKeyManagers(), null, null);
+
+                ssf = ctx.getServerSocketFactory();
+                return ssf;
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        } else {
+            return ServerSocketFactory.getDefault();
+        }
+        return null;
+    }
+}

--- a/sockets/server/ClassServer.java
+++ b/sockets/server/ClassServer.java
@@ -1,0 +1,189 @@
+/*
+ *
+ * Copyright (c) 1994, 2004, Oracle and/or its affiliates. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or
+ * without modification, are permitted provided that the following
+ * conditions are met:
+ *
+ * -Redistribution of source code must retain the above copyright
+ * notice, this list of conditions and the following disclaimer.
+ *
+ * Redistribution in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in
+ * the documentation and/or other materials provided with the
+ * distribution.
+ *
+ * Neither the name of Oracle nor the names of
+ * contributors may be used to endorse or promote products derived
+ * from this software without specific prior written permission.
+ *
+ * This software is provided "AS IS," without a warranty of any
+ * kind. ALL EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+ * WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE OR NON-INFRINGEMENT, ARE HEREBY
+ * EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN") AND ITS LICENSORS SHALL
+ * NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT
+ * OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+ * DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR
+ * ANY LOST REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT,
+ * SPECIAL, CONSEQUENTIAL, INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER
+ * CAUSED AND REGARDLESS OF THE THEORY OF LIABILITY, ARISING OUT OF
+ * THE USE OF OR INABILITY TO USE THIS SOFTWARE, EVEN IF SUN HAS
+ * BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+ *
+ * You acknowledge that this software is not designed, licensed or
+ * intended for use in the design, construction, operation or
+ * maintenance of any nuclear facility.
+ */
+
+import java.io.*;
+import java.net.*;
+import javax.net.*;
+
+/*
+ * ClassServer.java -- a simple file server that can serve
+ * Http get request in both clear and secure channel
+ */
+
+/**
+ * Based on ClassServer.java in tutorial/rmi
+ */
+public abstract class ClassServer implements Runnable {
+
+    private ServerSocket server = null;
+    /**
+     * Constructs a ClassServer based on <b>ss</b> and
+     * obtains a file's bytecodes using the method <b>getBytes</b>.
+     *
+     */
+    protected ClassServer(ServerSocket ss)
+    {
+        server = ss;
+        newListener();
+    }
+
+    /**
+     * Returns an array of bytes containing the bytes for
+     * the file represented by the argument <b>path</b>.
+     *
+     * @return the bytes for the file
+     * @exception FileNotFoundException if the file corresponding
+     * to <b>path</b> could not be loaded.
+     * @exception IOException if error occurs reading the class
+     */
+    public abstract byte[] getBytes(String path)
+        throws IOException, FileNotFoundException;
+
+    /**
+     * The "listen" thread that accepts a connection to the
+     * server, parses the header to obtain the file name
+     * and sends back the bytes for the file (or error
+     * if the file is not found or the response was malformed).
+     */
+    public void run()
+    {
+        Socket socket;
+
+        // accept a connection
+        try {
+            socket = server.accept();
+        } catch (IOException e) {
+            System.out.println("Class Server died: " + e.getMessage());
+            e.printStackTrace();
+            return;
+        }
+
+        // create a new thread to accept the next connection
+        newListener();
+
+        try {
+            OutputStream rawOut = socket.getOutputStream();
+
+            PrintWriter out = new PrintWriter(
+                                new BufferedWriter(
+                                new OutputStreamWriter(
+                                rawOut)));
+            try {
+                // get path to class file from header
+                BufferedReader in =
+                    new BufferedReader(
+                        new InputStreamReader(socket.getInputStream()));
+                String path = getPath(in);
+                // retrieve bytecodes
+                byte[] bytecodes = getBytes(path);
+                // send bytecodes in response (assumes HTTP/1.0 or later)
+                try {
+                    out.print("HTTP/1.0 200 OK\r\n");
+                    out.print("Content-Length: " + bytecodes.length +
+                                   "\r\n");
+                    out.print("Content-Type: text/html\r\n\r\n");
+                    out.flush();
+                    rawOut.write(bytecodes);
+                    rawOut.flush();
+                } catch (IOException ie) {
+                    ie.printStackTrace();
+                    return;
+                }
+
+            } catch (Exception e) {
+                e.printStackTrace();
+                // write out error response
+                out.println("HTTP/1.0 400 " + e.getMessage() + "\r\n");
+                out.println("Content-Type: text/html\r\n\r\n");
+                out.flush();
+            }
+
+        } catch (IOException ex) {
+            // eat exception (could log error to log file, but
+            // write out to stdout for now).
+            System.out.println("error writing response: " + ex.getMessage());
+            ex.printStackTrace();
+
+        } finally {
+            try {
+                socket.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+
+    /**
+     * Create a new thread to listen.
+     */
+    private void newListener()
+    {
+        (new Thread(this)).start();
+    }
+
+    /**
+     * Returns the path to the file obtained from
+     * parsing the HTML header.
+     */
+    private static String getPath(BufferedReader in)
+        throws IOException
+    {
+        String line = in.readLine();
+        String path = "";
+        // extract class from GET line
+        if (line.startsWith("GET /")) {
+            line = line.substring(5, line.length()-1).trim();
+            int index = line.indexOf(' ');
+            if (index != -1) {
+                path = line.substring(0, index);
+            }
+        }
+
+        // eat the rest of header
+        do {
+            line = in.readLine();
+        } while ((line.length() != 0) &&
+                 (line.charAt(0) != '\r') && (line.charAt(0) != '\n'));
+
+        if (path.length() != 0) {
+            return path;
+        } else {
+            throw new IOException("Malformed Header");
+        }
+    }
+}

--- a/sockets/server/test.txt
+++ b/sockets/server/test.txt
@@ -1,0 +1,4 @@
+Hello World!!
+
+
+

--- a/test-ocsp.sh
+++ b/test-ocsp.sh
@@ -60,7 +60,7 @@ build_client_app() {
 run_client_app() {
 
    cd $ROOTDIR/client-app
-   java -jar $JAR ledger.$DOMAIN 6865 $CLIENT_CERT $CLIENT_KEY $CA_CERT $AUTH_TOKEN
+   java -Djava.security.properties=$ROOTDIR/java.security -Dcom.sun.net.ssl.checkRevocation=true -Djava.security.debug="certpath ocsp" -Djdk.tls.client.enableStatusRequestExtension=true -jar $JAR ledger.$DOMAIN 6865 $CLIENT_CERT $CLIENT_KEY $CA_CERT $AUTH_TOKEN
 
 }
 

--- a/test-tls.sh
+++ b/test-tls.sh
@@ -24,5 +24,5 @@ echo | openssl s_client -connect "web.$DOMAIN:443" -CAfile certs/intermediate/ce
 
 echo ""
 echo "Testing sandbox"
-echo | openssl s_client -connect "ledger.$DOMAIN:6865" -CAfile certs/intermediate/certs/ca-chain.cert.pem -tls1_2
+echo | openssl s_client -connect "ledger.$DOMAIN:6865" -servername "ledger.$DOMAIN" -CAfile certs/intermediate/certs/ca-chain.cert.pem -tls1_2 -tlsextdebug -status
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -1,0 +1,47 @@
+{
+  "name": "auth0-react-01-login",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "start": "BROWSER=NONE SKIP_PREFLIGHT_CHECK=true react-scripts start",
+    "build": "SKIP_PREFLIGHT_CHECK=true react-scripts build",
+    "test": "SKIP_PREFLIGHT_CHECK=true react-scripts test",
+    "eject": "SKIP_PREFLIGHT_CHECK=true react-scripts eject"
+  },
+  "proxy": "https://web.acme.com:8000",
+  "dependencies": {
+    "@auth0/auth0-spa-js": "^1.10.0",
+    "@fortawesome/fontawesome-svg-core": "^1.2.29",
+    "@fortawesome/free-solid-svg-icons": "^5.13.1",
+    "@fortawesome/react-fontawesome": "^0.1.11",
+    "express": "^4.16.4",
+    "highlight.js": "^10.1.1",
+    "morgan": "^1.10.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
+    "react-router-dom": "^5.2.0",
+    "react-scripts": "4.0.3",
+    "reactstrap": "^8.4.1"
+  },
+  "devDependencies": {},
+  "resolutions": {
+    "webpack": "4.43.0",
+    "webpack-dev-server": "3.11.0",
+    "chokidar": "^3.4.0"
+  },
+  "eslintConfig": {
+    "extends": "react-app"
+  },
+  "browserslist": {
+    "production": [
+      ">0.2%",
+      "not dead",
+      "not op_mini all"
+    ],
+    "development": [
+      "last 1 chrome version",
+      "last 1 firefox version",
+      "last 1 safari version"
+    ]
+  }
+}

--- a/ui/src/auth_config.json
+++ b/ui/src/auth_config.json
@@ -1,5 +1,5 @@
 {
-  "domain": "digitalasset-dev.auth0.com",
-  "clientId": "Pe2Emu15eRdBHsXi0aEvyefaoSEz6jko",
+  "domain": "<autho-tenant-domain>.auth0.com",
+  "clientId": "<auth0-client-id>",
   "audience": "https://daml.com/ledger-api"
 }


### PR DESCRIPTION
Changes:
- Added testing for postgres TLS enforcement and hardening of database (CIS Benchmark)
- OCSP Testing including OCSP Stapling - TLS client/Server, Daml test app
- Documentation Updates for TechNote
- Testing with custom daml-on-postgres with JDK as TLS provider (for OCSP Stapling)